### PR TITLE
[Docs] Add nghttp2 instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # NIO-APNS
 
 Apple Push Notification Service client using the Swift NIO framework.
+
+
+### Note
+
+This project transitively depends on `https://github.com/apple/swift-nio-http2`, which requires you to have `nghttp2` on your linker path.  You can follow the instructions in the [README](https://github.com/apple/swift-nio-http2/blob/master/README.md)  there to figure out how to install `nghttp2`


### PR DESCRIPTION
Adds a note about the potential for needing to install nghttp2
in order to build this library.